### PR TITLE
セッション周り

### DIFF
--- a/app/assets/javascripts/prototypes.coffee
+++ b/app/assets/javascripts/prototypes.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/protospace.css.scss
+++ b/app/assets/stylesheets/protospace.css.scss
@@ -1,9 +1,8 @@
 /* -- import Roboto Font ------------------------------ */
 @import "//fonts.googleapis.com/css?family=Lato:300,400,700";
 
-/*-- Body style ---------------------------------- */
+/*-- Templete style ---------------------------------- */
 body {
-  font-family: "Lato", 'Helvetica Neue, Helvetica, Arial', sans-serif;
   font-style: normal;
   font-weight: 300;
   font-size: 14px;
@@ -18,6 +17,9 @@ body {
   -moz-font-feature-settings: "liga", "kern";
 }
 
+footer {
+  text-align:center;
+}
 /* -- Main style ------------------------------------ */
 .btn {
   font-family: "Lato", 'Helvetica Neue, Helvetica, Arial', sans-serif;
@@ -261,6 +263,11 @@ body {
     padding: 8px 0 0;
   }
 
+  .navbar-right{
+    float: right !important;
+    margin-right: 15px;
+    }
+
   .btn a {
     color: #fff;
 
@@ -473,6 +480,16 @@ body {
   }
 }
 
+.col-md-offset-2 {
+    margin-left: 16.66666667%;
+}
+
+.col-md-8{
+  width:66.66666666667%;
+  float: left;
+  }
+
+
 .user-new {
   padding-top: 20px;
 
@@ -593,6 +610,16 @@ body {
       box-shadow: 0 1px 1px #eee;
     }
   }
+}
+
+input[type="submit"] {
+  background-color: #337ab7;
+  width: 300px;
+  height: 47px;
+  text-align:centar;
+  font-size:20px;
+  color:#fff;
+
 }
 
 /*-- tag --------------------------------------------- */

--- a/app/assets/stylesheets/prototypes.scss
+++ b/app/assets/stylesheets/prototypes.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the prototypes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,13 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+    def after_sign_out_path_for(resource)
+      '/users/sign_in' # サインアウト後のリダイレクト先URL
+    end
+
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :avatar, :profile, :member, :works])
+    end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,0 +1,12 @@
+class PrototypesController < ApplicationController
+
+  def index
+  end
+
+  def new
+  end
+
+  def show
+  end
+  
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,12 @@
 class UsersController < ApplicationController
+
+  def edit
+  end
+
+  def index
+  end
+
+  def show
+  end
+  
 end

--- a/app/helpers/prototypes_helper.rb
+++ b/app/helpers/prototypes_helper.rb
@@ -1,0 +1,2 @@
+module PrototypesHelper
+end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,28 +2,28 @@
   -devise_error_messages!
   .col-md-8.col-md-offset-2
     %header.row.user-nav.row
-  .col-md-12
-    %h2 Register
-  .user-name_image.row
-  .user-name.col-md-10
-    =f.text_field :nickname, placeholder: "Username"
-  .user-image.col-md-2
-    %button.btn.btn-primary Add image
-    =f.file_field :avator
-    =f.email_field :email, placeholder: "E-Mail", class: "user-email"
-    =f.password_field :password, placeholder: "Password", class: "user-password"
-  .col-md-12
-    %h4 Member of
-    .user-user-member.row
-    .user-name.col-md-12
-      =f.text_field :member, placeholder: "Member"
+      .col-md-12
+        %h2 Register
+        .user-name_image.row
+          .user-name.col-md-10
+            =f.text_field :nickname, placeholder: "Username"
+        .user-image.col-md-2
+        %button.btn.btn-primary Add image
+        =f.file_field :avator
+        =f.email_field :email, placeholder: "E-Mail", class: "user-email"
+        =f.password_field :password, placeholder: "Password", class: "user-password"
+      .col-md-12
+        %h4 Member of
+        .user-user-member.row
+          .user-name.col-md-12
+            =f.text_field :member, placeholder: "Member"
       %h4 Profile
-    .user-user-profile.row
-    .user-name.col-md-12
-      =f.text_area :profile, placeholder: "Profile", cols: "30", rows: "4"
+      .user-user-profile.row
+        .user-name.col-md-12
+          =f.text_area :profile, placeholder: "Profile", cols: "30", rows: "4"
       %h4 Works
-    .user-name_image.row
-    .user-name.col-md-12
-      =f.text_area :works, placeholder: "Works", cols: "30", rows: "4"
-    .row.text-center.user-btn
-      %button.btn.btn-lg.btn-primary.btn-block{:type => "submit"} Save
+      .user-name_image.row
+        .user-name.col-md-12
+          =f.text_area :works, placeholder: "Works", cols: "30", rows: "4"
+  .row.text-center.user-btn
+    %button.btn.btn-lg.btn-primary.btn-block{:type => "submit"} Save

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,33 +1,29 @@
-%form#new_user.container.user-new{"accept-charset" => "UTF-8", :action => "/users", :enctype => "multipart/form-data", :method => "post"}
-    %input{:name => "utf8", :type => "hidden", :value => "✓"}/
-    %input{:name => "authenticity_token", :type => "hidden", :value => "S1tWtRVOZwtrsAFVWGSc0rC6nSPJwY6uuL6/T0ggsLR890fsyRgGXmHIVMrno9/VD8jCjEXSubIauwDS1K5Avw=="}/
-    .col-md-8.col-md-offset-2
+=form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "container user-new"}) do |f|
+  -devise_error_messages!
+  .col-md-8.col-md-offset-2
     %header.row.user-nav.row
-        .col-md-12
-        %h2 Register
-        .user-name_image.row
-            .user-name.col-md-10
-            %input#user_username{:autofocus => "autofocus", :name => "user[nickname]", :placeholder => "Username", :type => "text"}/
-            .user-image.col-md-2
-            %img#user_avatar.media-object{:alt => "64x64", "data-holder-rendered" => "true", "data-src" => "holder.js/64x64", :src => "", :style => "display:none; width:100%; height:100%;"}/
-            %button.btn.btn-primary
-                Add Image
-            %input#upload_avatar{:name => "user[avatar]", :type => "file"}/
-            %input#user_email.user-email{:autofocus => "autofocus", :name => "user[email]", :placeholder => "E-Mail", :type => "email", :value => ""}/
-            %input#user_password.user-password{:autocomplete => "off", :name => "user[password]", :placeholder => "Password", :type => "password"}/
-        .col-md-12
-        %h4 Member of
-        .user-user-member.row
-        .user-name.col-md-12
-        %input#user_group{:autofocus => "autofocus", :name => "user[member]", :placeholder => "Member", :type => "text"}
-        %h4 Profile
-        .user-user-profile.row
-        .user-name.col-md-12
-        %textarea#user_profile{:cols => "30", :name => "user[profile]", :placeholder => "Profile", :rows => "4"}
-        %h4 Works
-        .user-name_image.row
-        .user-name.col-md-12
-        %textarea#user_work{:cols => "30", :name => "user[works]", :placeholder => "Works", :rows => "4"}
-        .row.text-center.user-btn
-        %input.btn.btn-lg.btn-primary.btn-block{:name => "commit", :type => "submit", :value => "Save"}
-        Save
+  .col-md-12
+    %h2 Register
+  .user-name_image.row
+  .user-name.col-md-10
+    =f.text_field :nickname, placeholder: "Username"
+  .user-image.col-md-2
+    %button.btn.btn-primary Add image
+    =f.file_field :avator
+    =f.email_field :email, placeholder: "E-Mail", class: "user-email"
+    =f.password_field :password, placeholder: "Password", class: "user-password"
+  .col-md-12
+    %h4 Member of
+    .user-user-member.row
+    .user-name.col-md-12
+      =f.text_field :member, placeholder: "Member"
+      %h4 Profile
+    .user-user-profile.row
+    .user-name.col-md-12
+      =f.text_area :profile, placeholder: "Profile", cols: "30", rows: "4"
+      %h4 Works
+    .user-name_image.row
+    .user-name.col-md-12
+      =f.text_area :works, placeholder: "Works", cols: "30", rows: "4"
+    .row.text-center.user-btn
+      %button.btn.btn-lg.btn-primary.btn-block{:type => "submit"} Save

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,28 +1,33 @@
-%form.container.user-new{action: ""}
-  .col-md-8.col-md-offset-2
+%form#new_user.container.user-new{"accept-charset" => "UTF-8", :action => "/users", :enctype => "multipart/form-data", :method => "post"}
+    %input{:name => "utf8", :type => "hidden", :value => "✓"}/
+    %input{:name => "authenticity_token", :type => "hidden", :value => "S1tWtRVOZwtrsAFVWGSc0rC6nSPJwY6uuL6/T0ggsLR890fsyRgGXmHIVMrno9/VD8jCjEXSubIauwDS1K5Avw=="}/
+    .col-md-8.col-md-offset-2
     %header.row.user-nav.row
-      .col-md-12
+        .col-md-12
         %h2 Register
         .user-name_image.row
-          .user-name.col-md-10
-            %input{type: "text", placeholder: "Username"}/
-          .user-image.col-md-2
-            %button.btn.btn-primary Add image
-            %input{type: "file"}/
-        %input.user-email{type: "email", placeholder: "E-Mail"}/
-        %input.user-password{type: "password", placeholder: "Password"}/
-      .col-md-12
+            .user-name.col-md-10
+            %input#user_username{:autofocus => "autofocus", :name => "user[nickname]", :placeholder => "Username", :type => "text"}/
+            .user-image.col-md-2
+            %img#user_avatar.media-object{:alt => "64x64", "data-holder-rendered" => "true", "data-src" => "holder.js/64x64", :src => "", :style => "display:none; width:100%; height:100%;"}/
+            %button.btn.btn-primary
+                Add Image
+            %input#upload_avatar{:name => "user[avatar]", :type => "file"}/
+            %input#user_email.user-email{:autofocus => "autofocus", :name => "user[email]", :placeholder => "E-Mail", :type => "email", :value => ""}/
+            %input#user_password.user-password{:autocomplete => "off", :name => "user[password]", :placeholder => "Password", :type => "password"}/
+        .col-md-12
         %h4 Member of
         .user-user-member.row
-          .user-name.col-md-12
-            %input{type: "text", placeholder: "Member"}/
+        .user-name.col-md-12
+        %input#user_group{:autofocus => "autofocus", :name => "user[member]", :placeholder => "Member", :type => "text"}
         %h4 Profile
         .user-user-profile.row
-          .user-name.col-md-12
-            %textarea{name: "textarea", cols: "30", rows: "4", placeholder: "Profile"}
+        .user-name.col-md-12
+        %textarea#user_profile{:cols => "30", :name => "user[profile]", :placeholder => "Profile", :rows => "4"}
         %h4 Works
         .user-name_image.row
-          .user-name.col-md-12
-            %textarea{name: "textarea", cols: "30", rows: "4", placeholder: "Works"}
-    .row.text-center.user-btn
-      %button.btn.btn-lg.btn-primary.btn-block{type: "submit"} Save
+        .user-name.col-md-12
+        %textarea#user_work{:cols => "30", :name => "user[works]", :placeholder => "Works", :rows => "4"}
+        .row.text-center.user-btn
+        %input.btn.btn-lg.btn-primary.btn-block{:name => "commit", :type => "submit", :value => "Save"}
+        Save

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -13,4 +13,4 @@
   .text-center
     %p
       Not a member?
-      %a{href: "/users/sign_in"} Sign up now
+      %a{href: "/users/sign_up"} Sign up now

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,7 +1,7 @@
 .form-signin
   %h2.form-signin-heading
     Please sign in
-  = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
     .sr-only
       = f.label :email
       = f.email_field :email, placeholder: true, autofocus: true, required: true, class: "form-control"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,16 +1,20 @@
-.container
-  %form.form-signin
-    %h2.form-signin-heading Please sign in
-    %label.sr-only{for: "inputEmail"} Email address
-    %input#inputEmail.form-control{autofocus: "", placeholder: "Email address", required: "", type: "email"}/
-    %label.sr-only{for: "inputPassword"} Password
-    %input#inputPassword.form-control{placeholder: "Password", required: "", type: "password"}/
-    .checkbox
-      %label
-        %input{type: "checkbox", value: "remember-me"}/
-        Remember me
-    %button.btn.btn-lg.btn-primary.btn-block{type: "submit"} Sign in
-  .text-center
-    %p
-      Not a member?
-      %a{href: "/users/sign_up"} Sign up now
+.form-signin
+  %h2.form-signin-heading
+    Please sign in
+  = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+    .sr-only
+      = f.label :email
+      = f.email_field :email, placeholder: true, autofocus: true, required: true, class: "form-control"
+      .sr-only
+        = f.label :password
+        = f.password_field :password, placeholder: "Password", required: true, class: "form-control"
+      .checkbox
+        Remenber me
+        = f.label "remember_me"
+        = f.check_box :remember_me
+      .btn.btn-lg.btn-primary.btn-block
+        = f.submit "Sign in"
+      .text-center
+      %p
+        Not a member?
+        %a{href: "sign_up"} Sign up now

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,20 +1,18 @@
-.form-signin
-  %h2.form-signin-heading
-    Please sign in
-  = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-    .sr-only
-      = f.label :email
-      = f.email_field :email, placeholder: true, autofocus: true, required: true, class: "form-control"
+.continer
+  .form-signin
+    %h2.form-signin-heading
+      Please sign in
+    = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
       .sr-only
-        = f.label :password
+        = f.email_field :email, placeholder: "Email Adrdess", autofocus: true, required: true, class: "form-control"
+      .sr-only
         = f.password_field :password, placeholder: "Password", required: true, class: "form-control"
       .checkbox
-        Remenber me
-        = f.label "remember_me"
         = f.check_box :remember_me
-      .btn.btn-lg.btn-primary.btn-block
-        = f.submit "Sign in"
-      .text-center
+        = f.label "remember_me"
+      .actions
+        = f.submit "SIGN IN"
+    .text-center
       %p
         Not a member?
         %a{href: "sign_up"} Sign up now

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -8,25 +8,27 @@
       = image_tag("logo.png", alt: "PROTO TYPE - SHARE THE PROTOTYPE", height: "36px")
     .navbar-collapse.collapse.navbar-responsive-collapse
       //not login
-      %ul.nav.navbar-nav.navbar-right
-        %li
-          .btn.btn-primary.navbar-btn
-            %a{href: "/login"}
-              Get Started
+      -unless user_signed_in?
+        %ul.nav.navbar-nav.navbar-right
+          %li
+            .btn.btn-primary.navbar-btn
+              = link_to  'Get Started', user_session_path
       //login
-      %ul.nav.navbar-nav.navbar-right
-        %li.dropdown
-          %a.dropdown-toggle{"aria-expanded" => "false", "data-toggle" => "dropdown", href: "#", role: "button"}
-            UserName
-            %span.caret
-          %ul.dropdown-menu{role: "menu"}
-            %li
-              %a{href: "users/:id"} My Page
-            %li
-              %a{href: "/users/:id/edit"} Profile Edit
-            %li
-              %a{href: "/users/sign_out"} Logout
-        %li
-          .btn.btn-primary.navbar-btn
-            %a{href: "/proto/new"}
-              New Proto
+      -if user_signed_in?
+        %ul.nav.navbar-nav.navbar-right
+          %li.dropdown
+            %a.dropdown-toggle{"aria-expanded" => "false", "data-toggle" => "dropdown", :href => "#", :role => "button"}
+              =current_user.nickname
+              %span.caret
+              %ul.dropdown-menu{:role => "menu"}
+                %li
+                  =link_to 'My Page', users_path, method: :get
+                %li
+                  =link_to 'Profile Edit', edit_user_registration_path, method: :get
+                %li
+                  =link_to 'Logout', destroy_user_session_path, method: :delete
+                %li
+                .btn.btn-primary.navbar-btn
+                  =link_to 'New Proto', new_prototype_path, :class => 'post'
+
+                  .navbar.navbar-default.navbar-static-top.navbar-fixed-top

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -21,9 +21,11 @@
             %span.caret
           %ul.dropdown-menu{role: "menu"}
             %li
-              %a{href: "#"} Profile Edit
+              %a{href: "users/:id"} My Page
             %li
-              %a{href: "#"} Logout
+              %a{href: "/users/:id/edit"} Profile Edit
+            %li
+              %a{href: "/users/sign_out"} Logout
         %li
           .btn.btn-primary.navbar-btn
             %a{href: "/proto/new"}

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,18 +1,17 @@
 .navbar.navbar-default.navbar-static-top.navbar-fixed-top
   .container
-    %button.navbar-toggle(type="button" data-toggle="collapse" data-target=".navbar-responsive-collapse")
-      %span.icon-bar
-      %span.icon-bar
-      %span.icon-bar
-    %a.navbar-brand(href="/")
-      = image_tag("logo.png", alt: "PROTO TYPE - SHARE THE PROTOTYPE", height: "36px")
+    / %button.navbar-toggle(type="button" data-toggle="collapse" data-target=".navbar-responsive-collapse")
+    %span.icon-bar
+    %span.icon-bar
+    %span.icon-bar
+  %a.navbar-brand(href="/")
+    = image_tag("logo.png", alt: "PROTO TYPE - SHARE THE PROTOTYPE", height: "36px")
     .navbar-collapse.collapse.navbar-responsive-collapse
       //not login
       -unless user_signed_in?
         %ul.nav.navbar-nav.navbar-right
-          %li
-            .btn.btn-primary.navbar-btn
-              = link_to  'Get Started', user_session_path
+          .btn.btn-primary.navbar-btn
+            = link_to  'Get Started', user_session_path
       //login
       -if user_signed_in?
         %ul.nav.navbar-nav.navbar-right

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -30,5 +30,3 @@
                 %li
                 .btn.btn-primary.navbar-btn
                   =link_to 'New Proto', new_prototype_path, :class => 'post'
-
-                  .navbar.navbar-default.navbar-static-top.navbar-fixed-top

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
+  resources :users, only: [:edit, :index, :show]
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Rails.application.routes.draw do
+
+  root 'prototypes#index'
+
   devise_for :users
+
   resources :users, only: [:edit, :index, :show]
+  resources :prototypes, only: [:index, :new, :show]
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/migrate/20161205054216_devise_create_users.rb
+++ b/db/migrate/20161205054216_devise_create_users.rb
@@ -5,6 +5,11 @@ class DeviseCreateUsers < ActiveRecord::Migration
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
 
+      t.text :avatar
+      t.text :profile
+      t.string :member
+      t.text :works
+
       ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at

--- a/db/migrate/20161215102901_add_column_to_users.rb
+++ b/db/migrate/20161215102901_add_column_to_users.rb
@@ -1,0 +1,6 @@
+class AddColumnToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :nickname, :string
+    add_column :users, :team, :string
+  end
+end

--- a/db/migrate/20161226040335_remove_team_from_users.rb
+++ b/db/migrate/20161226040335_remove_team_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveTeamFromUsers < ActiveRecord::Migration
+  def change
+    remove_column :users, :team, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161205054216) do
+ActiveRecord::Schema.define(version: 20161215102901) do
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  limit: 255,   default: "", null: false
@@ -30,6 +30,8 @@ ActiveRecord::Schema.define(version: 20161205054216) do
     t.string   "last_sign_in_ip",        limit: 255
     t.datetime "created_at",                                        null: false
     t.datetime "updated_at",                                        null: false
+    t.string   "nickname",               limit: 255
+    t.string   "team",                   limit: 255
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,18 +14,22 @@
 ActiveRecord::Schema.define(version: 20161205054216) do
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  limit: 255, default: "", null: false
-    t.string   "encrypted_password",     limit: 255, default: "", null: false
+    t.string   "email",                  limit: 255,   default: "", null: false
+    t.string   "encrypted_password",     limit: 255,   default: "", null: false
+    t.text     "avatar",                 limit: 65535
+    t.text     "profile",                limit: 65535
+    t.string   "member",                 limit: 255
+    t.text     "works",                  limit: 65535
     t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          limit: 4,   default: 0,  null: false
+    t.integer  "sign_in_count",          limit: 4,     default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip",     limit: 255
     t.string   "last_sign_in_ip",        limit: 255
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161215102901) do
+ActiveRecord::Schema.define(version: 20161226040335) do
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  limit: 255,   default: "", null: false
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 20161215102901) do
     t.datetime "created_at",                                        null: false
     t.datetime "updated_at",                                        null: false
     t.string   "nickname",               limit: 255
-    t.string   "team",                   limit: 255
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/test/controllers/prototypes_controller_test.rb
+++ b/test/controllers/prototypes_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PrototypesControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
#####セッション周りの実装！サインアウト、サインイン、サインアップ
 1. セッション周りに関するビューの変更
 2. protospace・applicationコントローラーの作成変更
 3. ルーティングの追加
 4. usersテーブルの作成

# why
1. 各ビューのボタンのパスを変更し、セッション周りを実装する
2. applicationコントローラーにconfigure_permitted_parametersメソッドを追加してデータベースに情報が保存されるようにするため。サインアウト後のビューの指定（今はsign_inのページを指定）
3. ルーティングでrootを設定！そのためにprotospaceコントローラーも作成！
4. usersテーブルの作成はdデバイス機能を実装するには欠かせないので